### PR TITLE
Update dependencies

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -11,10 +11,10 @@ links = [
 gleam = ">= 0.32.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.31"
-gleam_json = "~> 0.6"
-gleam_http = "~> 3.5"
+gleam_stdlib = ">= 0.31.0 and < 2.0.0"
+gleam_json = ">= 0.6.0 and < 3.0.0"
+gleam_http = ">= 3.5.0 and < 5.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
-gleam_httpc = "~> 2.1"
+gleeunit = ">= 1.0.0 and < 2.0.0"
+gleam_httpc = ">= 2.1.0 and < 5.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,17 +2,17 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_http", version = "3.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0B09AAE8EB547C4F2F2D3F8917A0A4D2EF75DFF0232389332BAFE19DBBFDB92B" },
-  { name = "gleam_httpc", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_http"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "06AC1CA52C9BAA66C9D5C0303B2BF34E39AA1546BB96AEE496E4B06D513AB8C7" },
-  { name = "gleam_json", version = "0.7.0", build_tools = ["gleam"], requirements = ["thoas", "gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB405BD93A8828BCD870463DE29375E7B2D252D9D124C109E5B618AAC00B86FC" },
-  { name = "gleam_stdlib", version = "0.32.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "07D64C26D014CF570F8ACADCE602761EA2E74C842D26F2FD49B0D61973D9966F" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
-  { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
+  { name = "gleam_http", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0A62451FC85B98062E0907659D92E6A89F5F3C0FBE4AB8046C99936BF6F91DBC" },
+  { name = "gleam_httpc", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "1A38507AF26CACA145248733688703EADCB734EA971D4E34FB97B7613DECF132" },
+  { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
+  { name = "gleam_stdlib", version = "0.59.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F8FEE9B35797301994B81AF75508CF87C328FE1585558B0FFD188DC2B32EAA95" },
+  { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
 ]
 
 [requirements]
-gleam_http = { version = "~> 3.5" }
-gleam_httpc = { version = "~> 2.1" }
-gleam_json = { version = "~> 0.6" }
-gleam_stdlib = { version = "~> 0.31" }
-gleeunit = { version = "~> 1.0" }
+gleam_http = { version = ">= 3.5.0 and < 5.0.0" }
+gleam_httpc = { version = ">= 2.1.0 and < 5.0.0" }
+gleam_json = { version = ">= 0.6.0 and < 3.0.0" }
+gleam_stdlib = { version = ">= 0.31.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.0 and < 2.0.0" }


### PR DESCRIPTION
Hey!

I stumbled across `wimp` while looking for a way to send myself push notfications, but unfortunately its dependencies are too out of date and it won't build under the current stdlib. So I just went ahead and updated the version constraints for myself and it seems to build and work correctly now, so I thought I might as well PR it.

Let me know if you'd like me to change the constraints at all!